### PR TITLE
Upgrade nvCOMP to 3.0.0

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -53,12 +53,12 @@
       ]
     },
     "nvcomp" : {
-      "version" : "2.6.1",
+      "version" : "3.0.0",
       "git_url" : "https://github.com/NVIDIA/nvcomp.git",
       "git_tag" : "v2.2.0",
       "proprietary_binary" : {
-        "x86_64-linux" :  "https://developer.download.nvidia.com/compute/nvcomp/${version}/local_installers/nvcomp_${version}_x86_64_${cuda-toolkit-version-major}.x.tgz",
-        "aarch64-linux" : "https://developer.download.nvidia.com/compute/nvcomp/${version}/local_installers/nvcomp_${version}_SBSA_${cuda-toolkit-version-major}.x.tgz"
+        "x86_64-linux" :  "https://developer.download.nvidia.com/compute/nvcomp/3.0/local_installers/nvcomp_${version}_x86_64_${cuda-toolkit-version-major}.x.tgz",
+        "aarch64-linux" : "https://developer.download.nvidia.com/compute/nvcomp/3.0/local_installers/nvcomp_${version}_SBSA_${cuda-toolkit-version-major}.x.tgz"
       }
     },
     "rmm" : {


### PR DESCRIPTION
## Description
Upgrade nvCOMP version from 2.6.1 to 3.0.0.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
